### PR TITLE
Performance improvement for cooperativeMCTS

### DIFF
--- a/GameMoves.py
+++ b/GameMoves.py
@@ -34,6 +34,8 @@ class GameMoves:
         self.image = image
         self.tau = tau
         self.image_index = image_index
+        self.maxVal = np.max(image)
+        self.minVal = np.min(image)
 
         feature_extraction = FeatureExtraction(pattern='grey-box')
         kps = feature_extraction.get_key_points(self.image, num_partition=10)
@@ -119,17 +121,26 @@ class GameMoves:
 
     def applyManipulation(self, image, manipulation):
         # apply a specific manipulation to have a manipulated input
+        #image1 = copy.deepcopy(image)
+        #maxVal = np.max(image1)
+        #minVal = np.min(image1)
+        #for elt in list(manipulation.keys()):
+        #    (fst, snd, thd) = elt
+        #    image1[fst][snd][thd] += manipulation[elt]
+        #    if image1[fst][snd][thd] < minVal:
+        #        image1[fst][snd][thd] = minVal
+        #    elif image1[fst][snd][thd] > maxVal:
+        #        image1[fst][snd][thd] = maxVal
+        #return image1
         image1 = copy.deepcopy(image)
-        maxVal = np.max(image1)
-        minVal = np.min(image1)
-        for elt in list(manipulation.keys()):
-            (fst, snd, thd) = elt
-            image1[fst][snd][thd] += manipulation[elt]
-            if image1[fst][snd][thd] < minVal:
-                image1[fst][snd][thd] = minVal
-            elif image1[fst][snd][thd] > maxVal:
-                image1[fst][snd][thd] = maxVal
-        return image1
+        if len(manipulation.keys())>0:
+           a = np.array(list(manipulation.keys()))
+           image1[a[:,0],a[:,1],a[:,2]]=np.clip(image1[a[:,0],a[:,1],a[:,2]]
+                                                  +np.array(list(manipulation.values()))
+                                                ,self.maxVal,self.minVal)
+           return image1
+        else:
+           return image1
 
 
 """

--- a/NeuralNetwork.py
+++ b/NeuralNetwork.py
@@ -19,7 +19,7 @@ from matplotlib import pyplot as plt
 
 from basics import assure_path_exists
 from DataSet import *
-
+import numpy as np
 
 # Define a Neural Network class.
 class NeuralNetwork:
@@ -30,12 +30,19 @@ class NeuralNetwork:
         assure_path_exists("%s_pic/" % self.data_set)
 
     def predict(self, image):
-        import numpy as np
         image = np.expand_dims(image, axis=0)
         predict_value = self.model.predict(image)
         new_class = np.argmax(np.ravel(predict_value))
         confident = np.amax(np.ravel(predict_value))
         return new_class, confident
+
+    def predict_with_margin(self, image):
+        image = np.expand_dims(image, axis=0)
+        predict_value = self.model.predict(image)
+        new_class = np.argmax(np.ravel(predict_value))
+        confident = np.amax(np.ravel(predict_value))
+        margin = confident - np.sort(np.ravel(predict_value))[-2]
+        return new_class, confident, margin
 
     # To train a neural network.
     def train_network(self):


### PR DESCRIPTION
Hi,
I tried out your tool and found some tweaks to improve the performance of the "upperbound" method "cooperativeMCTS". Therefore the "applyManipulation" and "sampleNext" methods were rewritten. Its seems this updates yield a performance improvement of roughly 2x. 
Example:
For the input "python3 main.py cifar10 ub cooperative 0 L2 4 1" the duration of the first iteration was improved from 5.65s to 2.55s. 
I would be happy, if you would consider to include this improvements in your repository.  